### PR TITLE
Add gold style toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,11 @@
   <meta name="description" content="Warum AI Development weit mehr ist als Prompting: Product Ownership, Architektur, Qualität und sichere Auslieferung.">
   <meta name="theme-color" content="#07111f">
   <title>AI Development is Product Ownership</title>
+  <script>
+    if (localStorage.getItem("theme") === "gold") {
+      document.documentElement.dataset.theme = "gold";
+    }
+  </script>
   <style>
     :root {
       color-scheme: dark;
@@ -16,6 +21,32 @@
       --accent: #62d9ff;
       --deep: #07111f;
       --deep-2: #0a2036;
+      --accent-glow: rgba(98, 217, 255, .13);
+      --accent-hover: rgba(98, 217, 255, .75);
+      --accent-tint: rgba(98, 217, 255, .08);
+      --ice-line: rgba(188, 236, 255, .85);
+      --ice-border: rgba(188, 236, 255, .3);
+      --ice-tint: rgba(188, 236, 255, .2);
+      --accent-fade: rgba(98, 217, 255, .05);
+      --body-ink: #d9edf7;
+    }
+
+    :root[data-theme="gold"] {
+      --ink: #fff8e7;
+      --muted: #d8c49a;
+      --line: rgba(255, 226, 153, .2);
+      --ice: #f3d685;
+      --accent: #D4A843;
+      --deep: #171005;
+      --deep-2: #302009;
+      --accent-glow: rgba(212, 168, 67, .16);
+      --accent-hover: rgba(212, 168, 67, .8);
+      --accent-tint: rgba(212, 168, 67, .12);
+      --ice-line: rgba(243, 214, 133, .85);
+      --ice-border: rgba(243, 214, 133, .35);
+      --ice-tint: rgba(243, 214, 133, .2);
+      --accent-fade: rgba(212, 168, 67, .08);
+      --body-ink: #f7e8bd;
     }
 
     * { box-sizing: border-box; }
@@ -28,8 +59,8 @@
       font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
       color: var(--ink);
       background:
-        radial-gradient(circle at 20% 5%, rgba(98, 217, 255, .13), transparent 34rem),
-        linear-gradient(180deg, #07111f 0%, #081a2d 48%, #04101d 100%);
+        radial-gradient(circle at 20% 5%, var(--accent-glow), transparent 34rem),
+        linear-gradient(180deg, var(--deep) 0%, var(--deep-2) 48%, var(--deep) 100%);
     }
 
     a { color: inherit; }
@@ -70,6 +101,46 @@
       border-radius: 50%;
       background: #73f5b1;
       box-shadow: 0 0 18px rgba(115, 245, 177, .75);
+    }
+
+    .nav-actions {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+    }
+
+    .theme-toggle {
+      display: inline-flex;
+      align-items: center;
+      gap: 9px;
+      min-height: 38px;
+      padding: 5px 7px 5px 12px;
+      border: 1px solid var(--line);
+      border-radius: 999px;
+      color: var(--ink);
+      background: transparent;
+      cursor: pointer;
+      font: inherit;
+      font-size: .78rem;
+      font-weight: 800;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      transition: border-color .2s ease, background .2s ease;
+    }
+
+    .theme-toggle:hover,
+    .theme-toggle:focus-visible {
+      border-color: var(--accent-hover);
+      background: var(--accent-tint);
+    }
+
+    .theme-toggle::after {
+      content: "";
+      width: 26px;
+      height: 26px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: inset -7px -7px 0 rgba(0, 0, 0, .16);
     }
 
     .hero {
@@ -135,13 +206,13 @@
     .button:hover,
     .button:focus-visible {
       transform: translateY(-2px);
-      border-color: rgba(98, 217, 255, .75);
-      background: rgba(98, 217, 255, .08);
+      border-color: var(--accent-hover);
+      background: var(--accent-tint);
     }
 
     .button.primary {
       border-color: transparent;
-      color: #04101d;
+      color: var(--deep);
       background: var(--ice);
     }
 
@@ -160,15 +231,15 @@
       right: -24px;
       left: -24px;
       height: 1px;
-      background: linear-gradient(90deg, transparent, rgba(188, 236, 255, .85), transparent);
+      background: linear-gradient(90deg, transparent, var(--ice-line), transparent);
     }
 
     .tip,
     .body {
       width: 72%;
       justify-self: center;
-      border: 1px solid rgba(188, 236, 255, .3);
-      background: linear-gradient(145deg, rgba(188, 236, 255, .2), rgba(98, 217, 255, .05));
+      border: 1px solid var(--ice-border);
+      background: linear-gradient(145deg, var(--ice-tint), var(--accent-fade));
       backdrop-filter: blur(8px);
     }
 
@@ -205,7 +276,7 @@
     .body li {
       padding-bottom: 11px;
       border-bottom: 1px solid var(--line);
-      color: #d9edf7;
+      color: var(--body-ink);
       font-weight: 650;
     }
 
@@ -237,7 +308,9 @@
     @media (max-width: 520px) {
       main { width: min(100% - 28px, 1120px); padding-top: 22px; }
       nav { align-items: flex-start; margin-bottom: 60px; }
+      .nav-actions { gap: 10px; }
       .status { max-width: 130px; text-align: right; }
+      .theme-toggle { padding-left: 10px; font-size: .7rem; }
       .iceberg { min-height: 520px; }
       .body { padding: 40px 26px 32px; }
       .body ul { grid-template-columns: 1fr; gap: 9px; }
@@ -255,7 +328,10 @@
   <main>
     <nav aria-label="Seitennavigation">
       <div class="mark">wassertrinker.dev</div>
-      <div class="status">Case Study entsteht gerade</div>
+      <div class="nav-actions">
+        <div class="status">Case Study entsteht gerade</div>
+        <button class="theme-toggle" id="change-style" type="button" aria-pressed="false">Change Style</button>
+      </div>
     </nav>
 
     <section class="hero" aria-labelledby="headline">
@@ -301,5 +377,21 @@
       <span>Built transparently with Codex and specialized agents.</span>
     </footer>
   </main>
+  <script>
+    const styleToggle = document.getElementById("change-style");
+    styleToggle.setAttribute("aria-pressed", document.documentElement.dataset.theme === "gold");
+
+    styleToggle.addEventListener("click", () => {
+      const nextTheme = document.documentElement.dataset.theme === "gold" ? "default" : "gold";
+
+      if (nextTheme === "gold") {
+        localStorage.setItem("theme", "gold");
+      } else {
+        localStorage.removeItem("theme");
+      }
+
+      window.location.reload();
+    });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- add a Change Style toggle in the upper-right navigation
- persist the selected gold or default color scheme across reloads
- define the gold palette with `--accent: #D4A843`

## Validation

- `git diff --check`
- No automated test setup is present in this static site repository.

## Manual acceptance (passed)

- [x] The Change Style toggle is visible in the upper-right navigation.
- [x] The first click applies the gold color scheme and reloads the page.
- [x] The next click restores the default color scheme and reloads the page.

Closes #1
